### PR TITLE
Add functionality to close GameMenu when teleport icon is clicked

### DIFF
--- a/TeleportMenu.lua
+++ b/TeleportMenu.lua
@@ -588,6 +588,14 @@ local function CreateSecureButton(frame, type, text, id, hearthstone)
 			self.cooldownFrame:CheckCooldown(id, type)
 		end
 	)
+	
+	button:SetScript(
+	    "OnMouseDown", 
+		 function(self)
+			 ToggleGameMenu()
+		end
+	)
+	
 	button.cooldownFrame:CheckCooldown(id, type)
 
 	-- Textures
@@ -778,6 +786,9 @@ function tpm:CreateSeasonalTeleportFlyout()
 			local flyOutButton = CreateSecureButton(flyOutFrame, "spell", text, spellId)
 			local xOffset = globalWidth * flyoutsCreated
 			flyOutButton:SetPoint("TOPLEFT", flyOutFrame, "TOPLEFT", xOffset, 0)
+			flyOutButton:SetScript("OnMouseDown", function()
+				ToggleGameMenu()
+			end)
 		end
 	end
 	flyOutFrame:SetSize(globalWidth + (globalWidth * flyoutsCreated), globalHeight)
@@ -804,6 +815,9 @@ function tpm:CreateWormholeFlyout(flyoutData)
 		local flyOutButton = CreateSecureButton(flyOutFrame, "toy", nil, wormholeId)
 		local xOffset = globalWidth * flyoutsCreated
 		flyOutButton:SetPoint("TOPLEFT", flyOutFrame, "TOPLEFT", xOffset, 0)
+	    flyOutButton:SetScript("OnMouseDown", function()
+			ToggleGameMenu()
+		end)
 	end
 	flyOutFrame:SetSize(globalWidth * (flyoutsCreated + 1), globalHeight)
 
@@ -847,6 +861,12 @@ function tpm:updateHearthstone()
 			end
 		)
 	end
+	hearthstoneButton:SetScript(
+	    "OnMouseDown", 
+		function()
+			ToggleGameMenu()
+	end
+	)
 	hearthstoneButton:Show()
 end
 


### PR DESCRIPTION
In this update, I added a new feature that closes the GameMenu when a teleport icon is clicked.

This change was made to improve user experience by removing the need for hit esc to close the GameMenu when selecting a teleport option

Please feel free to let me know if I made any mistakes, as I am new to Lua programming, or if there are any improvements I could make.