### PR TITLE
Fix: Wormhole teleport error when checking usableWormholes length

### DIFF
--- a/Data/Wormholes.lua
+++ b/Data/Wormholes.lua
@@ -29,7 +29,7 @@ function tpm:UpdateAvailableWormholes()
 	tpm.AvailableWormholes = availableWormholes
 	tpm.AvailableWormholes.GetUsable = function()
 		if #tpm.AvailableWormholes == 0 then
-			return 0
+			return {}
 		end
 
 		local usableWormholes = {}

--- a/TeleportMenu.lua
+++ b/TeleportMenu.lua
@@ -705,13 +705,11 @@ function tpm:CreateWormholeFlyout(flyoutData)
 	button:SetPoint("LEFT", TeleportMeButtonsFrame, "TOPRIGHT", 0, yOffset)
 
 	local flyoutsCreated = 0
-	for _, wormholeId in ipairs(tpm.AvailableWormholes) do
-		if C_ToyBox.IsToyUsable(wormholeId) then
-			flyoutsCreated = flyoutsCreated + 1
-			local flyOutButton = CreateSecureButton(flyOutFrame, "toy", nil, wormholeId)
-			local xOffset = globalWidth * flyoutsCreated
-			flyOutButton:SetPoint("TOPLEFT", flyOutFrame, "TOPLEFT", xOffset, 0)
-		end
+	for _, wormholeId in ipairs(usableWormholes) do
+		flyoutsCreated = flyoutsCreated + 1
+		local flyOutButton = CreateSecureButton(flyOutFrame, "toy", nil, wormholeId)
+		local xOffset = globalWidth * flyoutsCreated
+		flyOutButton:SetPoint("TOPLEFT", flyOutFrame, "TOPLEFT", xOffset, 0)
 	end
 	flyOutFrame:SetSize(globalWidth * (flyoutsCreated + 1), globalHeight)
 


### PR DESCRIPTION
Fix error "attempt to get length of local 'usableWormholes' (a number value)" by ensuring GetUsable() returns an empty table instead of 0. Updated CreateWormholeFlyout function to properly handle the return value and removed redundant IsToyUsable check.