### PR TITLE
Add Shadowguard Translocator to item teleports

### DIFF
--- a/Data/Items.lua
+++ b/Data/Items.lua
@@ -121,7 +121,7 @@ tpm.ItemTeleports = {
 	[234392] = true, -- Gallagio Loyalty Rewards Card: Black
 	[234393] = true, -- Gallagio Loyalty Rewards Card: Diamond
 	[234394] = true, -- Gallagio Loyalty Rewards Card: Legendary
-	[249699] = true, --Shadowguard Translocator
+	[249699] = true, -- Shadowguard Translocator
 }
 
 function tpm:GetAvailableItemTeleports()

--- a/Data/Items.lua
+++ b/Data/Items.lua
@@ -121,6 +121,7 @@ tpm.ItemTeleports = {
 	[234392] = true, -- Gallagio Loyalty Rewards Card: Black
 	[234393] = true, -- Gallagio Loyalty Rewards Card: Diamond
 	[234394] = true, -- Gallagio Loyalty Rewards Card: Legendary
+	[249699] = true, --Shadowguard Translocator
 }
 
 function tpm:GetAvailableItemTeleports()


### PR DESCRIPTION
New teleport item from raid renown.

https://www.wowhead.com/item=249699/shadowguard-translocator