### PR TITLE
Fix Text Wrapping In Random Hearthstone's Tooltip

### DIFF
--- a/TeleportMenu.lua
+++ b/TeleportMenu.lua
@@ -268,7 +268,7 @@ local function setToolTip(self, tpType, id, hs)
 		local bindLocation = GetBindLocation()
 		GameTooltip:SetText(L["Random Hearthstone"], 1, 1, 1)
 		GameTooltip:AddLine(L["Random Hearthstone Tooltip"], 1, 1, 1)
-		GameTooltip:AddLine(L["Random Hearthstone Location"]:format(bindLocation), 1, 1, 1)
+		GameTooltip:AddLine(L["Random Hearthstone Location"]:format(bindLocation), 1, 1, 1, true) -- `false` is supposed to disable text wrapping, but somehow `true` works that way in action
 	elseif tpType == "item" then
 		GameTooltip:SetItemByID(id)
 	elseif tpType == "item_teleports" then


### PR DESCRIPTION
Fixes #167 

Special thanks to @nanjuekaien1 for the pointers & inspiration

Preview in en-US:

<img width="818" height="658" alt="image" src="https://github.com/user-attachments/assets/a52da8bd-1cdb-4230-9707-4b8c5a9a2e00" />

And in zh-CN:

<img width="711" height="636" alt="image" src="https://github.com/user-attachments/assets/5687a03c-5ea4-4ed0-84f3-9381ce9ea8ea" />


